### PR TITLE
test: unskip did:pkh spec compliance tests (issue #24 resolved)

### DIFF
--- a/tests/spec-compliance/omatrust-spec/did-formats.test.ts
+++ b/tests/spec-compliance/omatrust-spec/did-formats.test.ts
@@ -80,14 +80,10 @@ describe('OMATrust Specification: DID Format Requirements', () => {
     });
 
     /**
-     * KNOWN BUG: BUG-001 - normalizeDidWeb() incorrectly converts did:pkh to did:web
-     * See: OMATRUST_SPECIFICATION_REQUIREMENTS.md Section 5 - Known Issues
-     * 
-     * This test is skipped until the bug is fixed in @oma3/omatrust SDK.
-     * The prepareMintApp function calls normalizeDidWeb which incorrectly transforms
-     * did:pkh:eip155:1:0x... to did:web:did:pkh:eip155:1:0x...
+     * BUG-001 RESOLVED: prepareMintApp uses normalizeDid (from @oma3/omatrust) which
+     * correctly passes through did:pkh unchanged. did:pkh format is now fully supported.
      */
-    it.skip('accepts did:pkh format per OMATrust specification (BUG-001: normalizeDidWeb incorrectly converts did:pkh)', () => {
+    it('accepts did:pkh format per OMATrust specification', () => {
       /**
        * Specification: OMATrust Developer Documentation
        * URL: https://docs.oma3.org/
@@ -359,12 +355,10 @@ describe('OMATrust Specification: DID Format Requirements', () => {
     });
 
     /**
-     * KNOWN BUG: BUG-001 - normalizeDidWeb() incorrectly converts did:pkh to did:web
-     * See: OMATRUST_SPECIFICATION_REQUIREMENTS.md Section 5 - Known Issues
-     * 
-     * This test is skipped until the bug is fixed in @oma3/omatrust SDK.
+     * BUG-001 RESOLVED: did:pkh is correctly supported for smart contract registration
+     * via normalizeDid in prepareMintApp.
      */
-    it.skip('supports did:pkh for smart contract registration (BUG-001: normalizeDidWeb incorrectly converts did:pkh)', () => {
+    it('supports did:pkh for smart contract registration', () => {
       /**
        * Specification: OMATrust Developer Documentation
        * Section: What You Can Register


### PR DESCRIPTION
  ## Summary
  Unskips the did:pkh OMATrust spec compliance tests and updates BUG-001 comments to reflect that issue #24 is resolved.

  ## Changes
  - Unskip "accepts did:pkh format per OMATrust specification"
  - Unskip "supports did:pkh for smart contract registration"
  - Update BUG-001 comments to reflect resolved status

  ## Context
  prepareMintApp uses normalizeDid (from @oma3/omatrust) which correctly handles did:pkh. The bug described in issue #24 (normalizeDidWeb converting did:pkh to did:web) does not affect the mint path.